### PR TITLE
Set CVE-2017-5753 as mitigated for IE on KB4057401

### DIFF
--- a/MeltdownSpectreReport.ps1
+++ b/MeltdownSpectreReport.ps1
@@ -53,7 +53,7 @@
     Export-Csv -Path $env:USERPROFILE\Desktop\servers.txt -NoTypeInformation
 .NOTES
     Author: VRDSE
-    Version: 0.4.3
+    Version: 0.4.4
 #>
 [CmdletBinding()]
 param(
@@ -1110,7 +1110,8 @@ $GetMeltdownStatusInformation = {
         # Internet Explorer 
         if ($SystemInformation.isIE) {
             # KBs from https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/ADV180002
-            $IEUpdates = 'KB4056890', 'KB4056895', 'KB4056894', 'KB4056568', 'KB4056893', 'KB4056891', 'KB4056892'
+            # https://support.microsoft.com/en-US/help/4057401 added as it includes KB4056895
+            $IEUpdates = 'KB4056890', 'KB4056895', 'KB4056894', 'KB4056568', 'KB4056893', 'KB4056891', 'KB4056892', 'KB4057401'
             $Hotfixes = $SystemInformation.InstalledUpdates | Select-Object -ExpandProperty HotFixId
             $IEMitigated = IsHotfixInstalled $IEUpdates $Hotfixes
         } 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ Is `empty` if Edge was not found.
 
 ### CVE-2017-5753 mitigated in IE (aka Spectre Variant 1)
 Is `true` if one of the following Windows Updates is installed:
-'KB4056890', 'KB4056895', 'KB4056894', 'KB4056568', 'KB4056893', 'KB4056891', 'KB4056892'
+'KB4056890', 'KB4056895', 'KB4056894', 'KB4056568', 'KB4056893', 'KB4056891', 'KB4056892', 'KB4057401'
 
 The list of updates was obtained from [ADV180002 | Guidance to mitigate speculative execution side-channel vulnerabilities](https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/ADV180002).
+
+[KB4057401](https://support.microsoft.com/en-US/help/4057401) added as it includes KB4056895.
 
 Also see [Mitigating speculative execution side-channel attacks in Microsoft Edge and Internet Explorer](https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer/) for details.
 
@@ -208,6 +210,8 @@ else {
 This can be considered as the Hyper-V Guest equivalent to "microcode CPU update from hardware OEM".
 
 # History
+### 0.4.4
+* \* Accept KB4057401 as a substitute for KB4056895
 ### 0.4.3.1
 * \* Added support for Firefox ESR
 ### 0.4.3


### PR DESCRIPTION
[KB4057401][] -- _January 17, 2018 Preview of Monthly Rollup for Windows 8.1 and Windows Server 2012 R2 Standard_ -- includes [KB4056895][] -- _January 8, 2018 Monthly Rollup for Windows 8.1 and Windows Server 2012 R2 Standard_ -- resulting in the latter being 'not applicable'. IE itself however actually reports its Update Version as 11.0.50, [4056568][].

[kb4057401]: https://support.microsoft.com/en-US/help/4057401
[kb4056895]: https://support.microsoft.com/en-US/help/4056895
[4056568]: https://support.microsoft.com/en-US/help/4056568